### PR TITLE
Catch empty prompt

### DIFF
--- a/src/chatgpt_cli/chat.py
+++ b/src/chatgpt_cli/chat.py
@@ -45,6 +45,9 @@ def main():
     while True:
         try:
             user_message = user_input().strip()
+            if user_message == "":
+                continue
+
             if is_command(user_message):
                 execute_command(user_message, conv, tmpl)
                 continue


### PR DESCRIPTION
When writing and empty prompt, the script passes it on to ChatGPT, which doesn't make much sense. Added a guard clause to catch empty prompts.

I also refactored the `main` in `chat.py` to be more readable. If you don't want to implement this change and leave it as is, I will revert it and you can merge only the empty promt catch.