### PR TITLE
Support input prompts through editors like vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ We've provided several commands to help you use this tool more conveniently. You
 - `!resend`: resends your last prompt to generate response
 - `!edit`: selects messages for editing
 - `!drop`: selects messages for deletion
+- `!editor`: use your default editor (e.g. vim) to submit a message
 - `!exit` or `!quit`: exits the program
 
 Features (under development):

--- a/README_zh.md
+++ b/README_zh.md
@@ -105,6 +105,7 @@ proxy:
 - `!drop` 目前用于删除掉某一段消息，可以是 ChatGPT 的也可以是你发的
 - `!resend` 通常用于在发送失败的情况下，如遇到网络错误，重新发送上一次的消息
 - `!edit` 用于编辑会话，双方的话都可以编辑
+- `!editor`: 使用你的默认编辑器编辑你的想要发送的消息（如果系统环境变量没有设置，则默认为vim）
 - `!exit` 或者 `!quit` 退出，未保存的情况下也会提示是否保存
 
 Features (under development):
@@ -124,7 +125,7 @@ We have some todos for future improvements, such as:
 - [x] Detect `[Ctrl]+[C]` hotkey and prompt to confirm exiting
 - [ ] `!token`: Count tokens in conversation and display the total number
 - [ ] `!sum`: Generate a summary of the conversation to reduce token usage
-- [ ] `!tmpl`: Choose system prompt templates
+- [x] `!tmpl`: Choose system prompt templates
 - [ ] `!conv`: Show conversation list, Delete and Rename saved conversations
 - [ ] `!sys <command>`: Enable you to run system command
 

--- a/src/chatgpt_cli/chat.py
+++ b/src/chatgpt_cli/chat.py
@@ -38,19 +38,22 @@ def read_message(conv, tmpl):
     user_message = user_input()
 
     if is_command(user_message):
+        printmd("**[Command Executed]**")
         user_message = execute_command(user_message, conv, tmpl)
+        user_message = post_command_process(user_message)
 
     if user_message == "":
         return
 
     conv.add_user_message(user_message)
+    printmd("**[Input Submitted]**")
 
     assistant_message = generate_response(conv.messages)
     if assistant_message:
         assistant_output(assistant_message)
         conv.add_assistant_message(assistant_message)
-        return
-    conv.save(True)
+    else:
+        conv.save(True)
 
 
 def loop(conv, tmpl):
@@ -69,6 +72,7 @@ def main():
 
     conv = Conversation(default_prompt)
     conv.show_history()
+
     tmpl = Template()
     while True:
         loop(conv, tmpl)

--- a/src/chatgpt_cli/chat.py
+++ b/src/chatgpt_cli/chat.py
@@ -36,12 +36,13 @@ def setup_runtime_env() -> Dict:
 
 def read_message(conv, tmpl):
     user_message = user_input()
+
+    if is_command(user_message):
+        user_message = execute_command(user_message, conv, tmpl)
+
     if user_message == "":
         return
 
-    if is_command(user_message):
-        execute_command(user_message, conv, tmpl)
-        return
     conv.add_user_message(user_message)
 
     assistant_message = generate_response(conv.messages)

--- a/src/utils/cmd.py
+++ b/src/utils/cmd.py
@@ -1,5 +1,6 @@
 from chatgpt_cli.conversation import Conversation, Template
 from utils.io import *
+import re
 
 
 def is_command(user_msg: str) -> bool:
@@ -16,45 +17,44 @@ def execute_command(
     user_msg = user_msg.strip()
     if user_msg in ["!help", "help"]:
         show_welcome_panel()
-        user_msg = ""
     elif user_msg in ["!show", "show"]:
         conv.show_history()
-        user_msg = ""
     elif user_msg in ["!save", "save"]:
         conv.save(False)
-        user_msg = ""
     elif user_msg in ["!load", "load"]:
         conv.load()
         conv.show_history(panel=False)
-        user_msg = ""
     elif user_msg in ["!new", "new", "reset", "!reset"]:
         conv.reset()
         conv.show_history(panel=False)
-        user_msg = ""
     elif user_msg in ["!resend", "resend"]:
         conv.resend()
-        user_msg = ""
     elif user_msg in ["!regen", "regen"]:
         conv.regen()
-        user_msg = ""
     elif user_msg in ["!edit", "edit"]:
         conv.edit_messages()
-        user_msg = ""
     elif user_msg in ["!drop", "drop"]:
         conv.drop_messages()
-        user_msg = ""
     elif user_msg in ["!editor", "editor"]:
         message = input_from_editor()
-        user_msg = message
+        user_msg += " " + message
     elif user_msg in ["!exit", "!quit", "quit", "exit"]:
         conv.save(True)
-        user_msg = ""
         print("Bye!")
         exit(0)
     elif user_msg.startswith("!tmpl"):
         tmpl.execute_command(user_msg, conv)
-        user_msg = ""
     elif user_msg.startswith("!"):
         print("Invalid command, please try again")
-        user_msg = ""
     return user_msg
+
+
+def post_command_process(user_message):
+    # handle the return string of execute_command
+    pattern = re.compile(r"^!\w*\s*")
+    if user_message.startswith("!editor"):
+        user_message = pattern.sub("", user_message)
+        user_output(user_message)
+    else:
+        user_message = pattern.sub("", user_message)
+    return user_message

--- a/src/utils/cmd.py
+++ b/src/utils/cmd.py
@@ -34,6 +34,8 @@ def execute_command(
         conv.edit_messages()
     elif user_msg in ["!drop", "drop"]:
         conv.drop_messages()
+    elif user_msg in ["!editor", "editor"]:
+        set_input_from_editor(True)
     elif user_msg in ["!exit", "!quit", "quit", "exit"]:
         conv.save(True)
         print("Bye!")

--- a/src/utils/cmd.py
+++ b/src/utils/cmd.py
@@ -16,32 +16,45 @@ def execute_command(
     user_msg = user_msg.strip()
     if user_msg in ["!help", "help"]:
         show_welcome_panel()
+        user_msg = ""
     elif user_msg in ["!show", "show"]:
         conv.show_history()
+        user_msg = ""
     elif user_msg in ["!save", "save"]:
         conv.save(False)
+        user_msg = ""
     elif user_msg in ["!load", "load"]:
         conv.load()
         conv.show_history(panel=False)
+        user_msg = ""
     elif user_msg in ["!new", "new", "reset", "!reset"]:
         conv.reset()
         conv.show_history(panel=False)
+        user_msg = ""
     elif user_msg in ["!resend", "resend"]:
         conv.resend()
+        user_msg = ""
     elif user_msg in ["!regen", "regen"]:
         conv.regen()
+        user_msg = ""
     elif user_msg in ["!edit", "edit"]:
         conv.edit_messages()
+        user_msg = ""
     elif user_msg in ["!drop", "drop"]:
         conv.drop_messages()
+        user_msg = ""
     elif user_msg in ["!editor", "editor"]:
-        set_input_from_editor(True)
+        message = input_from_editor()
+        user_msg = message
     elif user_msg in ["!exit", "!quit", "quit", "exit"]:
         conv.save(True)
+        user_msg = ""
         print("Bye!")
         exit(0)
     elif user_msg.startswith("!tmpl"):
         tmpl.execute_command(user_msg, conv)
+        user_msg = ""
     elif user_msg.startswith("!"):
         print("Invalid command, please try again")
+        user_msg = ""
     return user_msg

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -103,7 +103,7 @@ def input_from_editor() -> str:
         subprocess.call([editor, tf.name])
 
         tf.seek(0)
-        msg = tf.read().decode()
+        msg = tf.read().decode().strip()
         return msg
 
 
@@ -122,9 +122,7 @@ def user_input(prompt="\nUser: ") -> str:
         prompt = "\r" + " " * len(prompt) + "\r" + " .... " + readline.get_line_buffer()
     # Print a message indicating that the input has been submitted
     msg = "\n".join(lines).strip()
-    if msg:
-        printmd("**[Input Submitted]**")
-    else:
+    if not msg:
         printmd("**[Empty Input Skipped]**")
     return msg
 
@@ -139,7 +137,7 @@ def user_input_from_editor():
 
         subprocess.call([editor, tf.name])
         tf.seek(0)
-        msg = tf.read().decode("utf-8")
+        msg = tf.read().decode("utf-8").strip()
     return msg
 
 
@@ -162,6 +160,7 @@ Here are some useful commands you may want to use:
 - `!resend`: resend your last prompt to generate response
 - `!edit`: select messages to edit
 - `!drop`: select messages to drop
+- `!editor`: use your default editor (e.g. vim) to submit a message
 - `!exit` or `!quit`: exit the program
 
 Features (under development):

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -14,8 +14,6 @@ from chatgpt_cli import __version__
 
 console = Console()
 
-input_from_editor = False
-
 
 def print(*args, **kwargs) -> None:
     console.print(*args, **kwargs)
@@ -94,19 +92,25 @@ def input_error_handler(is_modified: bool, e: Exception) -> None:
             continue
 
 
-def set_input_from_editor(new_value):
-    global input_from_editor
-    input_from_editor = new_value
+def input_from_editor() -> str:
+    editor = os.environ.get("EDITOR", "vim")
+    initial_message = b""
+
+    with tempfile.NamedTemporaryFile(suffix=".tmp") as tf:
+        tf.write(initial_message)
+        tf.flush()
+
+        subprocess.call([editor, tf.name])
+
+        tf.seek(0)
+        msg = tf.read().decode()
+        return msg
 
 
 def user_input(prompt="\nUser: ") -> str:
     """
     Get user input with support for multiple lines without submitting the message.
     """
-    if input_from_editor:
-        set_input_from_editor(False)
-        return user_input_from_editor()
-
     # Use readline to handle user input
     lines = []
     while True:

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -127,20 +127,6 @@ def user_input(prompt="\nUser: ") -> str:
     return msg
 
 
-def user_input_from_editor():
-    editor = os.environ.get("EDITOR", "vim")
-    initial_message = b""
-
-    with tempfile.NamedTemporaryFile(suffix=".tmp") as tf:
-        tf.write(initial_message)
-        tf.flush()
-
-        subprocess.call([editor, tf.name])
-        tf.seek(0)
-        msg = tf.read().decode("utf-8").strip()
-    return msg
-
-
 def show_welcome_panel():
     welcome_msg = f"""
 Welcome to ChatGPT CLI v{__version__}!


### PR DESCRIPTION
It is very useful to be able to write messages with a proper CLI editor like vim (similar to `git commit`) if you have longer prompts or need to copy paste text or code (pasting text for example does not work with the normal `user_input()`). The implementation of this is not so straightforward however. The current implementation uses a global flag in `io.py`, which is rather bad (but I don't know of a better way to do this, if you have any ideas, I am open to suggestions).

I also tried to implemented using [argparse](https://docs.python.org/3/library/argparse.html#module-argparse) but that went pretty horribly. Using `!editor` as a command is much better, especially because this way you can actually read you conversations with the assistant.

**TO DO**

- [x] Print the inputted message to the chat
- [x] Add the command to the rest of the repo (in help etc.)