### PR TITLE
fix: remove the use of line buffer

### DIFF
--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -2,7 +2,6 @@ import os
 import sys
 import tempfile
 import subprocess
-import readline
 from typing import Dict
 
 from rich import print
@@ -120,7 +119,6 @@ def user_input(prompt="\nUser: ") -> str:
         lines.append(line)
         # Update the prompt using readline
         prompt = "\r" + " " * len(prompt) + "\r" + " .... "
-        readline.get_line_buffer()
     # Print a message indicating that the input has been submitted
     msg = "\n".join(lines).strip()
     if not msg:


### PR DESCRIPTION
As issue #6 mentioned, the use of the original `readline` is not available on Windows, so we change it to use `pyreadline3`. But later the behavior seems still not correct on Windows (the behavior not changed on Linux though), a temporary solution was implemented in earlier PR #8.

However, I examine the code again, and truly think there is no need to use the `readline` module as it does not perform any valid functionality in handling the multiple-line input, but causes a problem in navigating the input history from line buffer at the terminal using the up-arrow key. 

The newline character is already handled automatically within the loop using `line = input(prompt)`, which receives the input by line (after typing `Enter` key). The `readline` is actually a misuse here, so I remove it and test the functionality again on both Linux and Windows. Everything seems to be correct.