### PR TITLE
Add a spinner that indicates the assistant is generating a response

### DIFF
--- a/src/chatgpt_cli/chat.py
+++ b/src/chatgpt_cli/chat.py
@@ -48,8 +48,7 @@ def read_message(conv, tmpl):
     conv.add_user_message(user_message)
     printmd("**[Input Submitted]**")
 
-    with console.status("[bold green]Generating response..."):
-        assistant_message = generate_response(conv.messages)
+    assistant_message = generate_response(conv.messages)
 
     if assistant_message:
         assistant_output(assistant_message)

--- a/src/chatgpt_cli/chat.py
+++ b/src/chatgpt_cli/chat.py
@@ -48,7 +48,9 @@ def read_message(conv, tmpl):
     conv.add_user_message(user_message)
     printmd("**[Input Submitted]**")
 
-    assistant_message = generate_response(conv.messages)
+    with console.status("[bold green]Generating response..."):
+        assistant_message = generate_response(conv.messages)
+
     if assistant_message:
         assistant_output(assistant_message)
         conv.add_assistant_message(assistant_message)

--- a/src/chatgpt_cli/conversation.py
+++ b/src/chatgpt_cli/conversation.py
@@ -9,10 +9,11 @@ from utils.file import *
 
 def generate_response(messages: List[Dict[str, str]]) -> str:
     try:
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",  # or gpt-3.5-turbo-0301
-            messages=messages,
-        )
+        with console.status("[bold green]Generating response..."):
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",  # or gpt-3.5-turbo-0301
+                messages=messages,
+            )
         assistant_message = response["choices"][0]["message"]["content"].strip()
         return assistant_message
     except openai.error.APIConnectionError as api_conn_err:


### PR DESCRIPTION
When you have long questions/answers it can be frustrating to see nothing going on inside the terminal. I added a spinner that shows that the assistant is generating it's response, the implementation is taken from [here](https://github.com/mbroton/chatgpt-api/blob/3e7da5702da6457ffbc635e950ba68c497f693e7/chatgpt/cli.py#L84).