### PR TITLE
fix(io): fix crash when EDITOR is a full command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chatgpt-cli-md"
-version = "0.1.11"
+version = "0.1.12"
 description = "A markdown-supported command-line interface tool that connects to ChatGPT using OpenAI's API key."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.8"

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -100,7 +100,7 @@ def input_from_editor() -> str:
         tf.write(initial_message)
         tf.flush()
 
-        subprocess.call([editor, tf.name])
+        subprocess.call(f"{editor} '{tf.name}'", shell=True)
 
         tf.seek(0)
         msg = tf.read().decode().strip()


### PR DESCRIPTION
when using a command with options as EDITOR e.g. `emacsclient -nw`, the `editor` command will crash the program:

```
FileNotFoundError: [Errno 2] No such file or directory: 'emacsclient -nw'
```

using `shell=True` in `subprocess` and formatting a command string from our parameters fixes this